### PR TITLE
Refactor directory configuration to use launch directory as root

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,97 @@
+# Migration Guide: Simplified Directory Configuration
+
+## What Changed
+
+The MCP Shell Server has been refactored to use a much simpler directory security model:
+
+### Before (v0.1.0 and earlier)
+- Required explicit configuration of `directories.allowed` and `directories.default`
+- Multiple allowed directories had to be pre-configured
+- Complex configuration files with directory paths
+
+### After (v0.2.0)
+- **Automatic root directory**: The server uses the directory where it was launched as the single root
+- **No configuration needed**: Directory restrictions are automatic based on launch location
+- **Simpler sandbox**: Commands can only execute within the launch directory and its subdirectories
+
+## Benefits
+
+1. **Simplified Setup**: No need to configure allowed directories in config files
+2. **Automatic Security**: Claude or other MCP clients automatically determine the sandbox boundary
+3. **Project-Aware**: Each project gets its own sandbox automatically
+4. **Intuitive Behavior**: The accessible directory matches where the user/AI started working
+
+## How It Works
+
+When Claude bootstraps the shemcp MCP server, it tells shemcp the broadest/highest directory of its sandbox by launching the server from that directory. The server then:
+
+1. Uses `process.cwd()` to detect where it was launched
+2. Restricts all shell operations to that directory and subdirectories
+3. Validates working directories using path resolution to prevent directory traversal attacks
+
+## Configuration Changes
+
+### Old Config File (no longer needed):
+```toml
+[directories]
+allowed = [
+    "~/projects",
+    "~/workspace", 
+    "~/dev"
+]
+default = "~/projects"
+```
+
+### New Config File (simplified):
+```toml
+[directories]
+# The root directory is automatically set to where the MCP server was launched
+# No configuration needed - all operations are restricted to this directory and subdirectories
+```
+
+## API Changes
+
+### Tool: `shell_set_cwd`
+- **Before**: Set the default working directory (must be in allowedCwds)
+- **After**: Set the root directory (must be within current root or subdirectory)
+
+### Tool: `shell_set_policy` 
+- **Before**: Could modify `allowed_cwds` and `default_cwd` parameters
+- **After**: Directory parameters removed - only command patterns, limits, and env vars configurable
+
+## Migration Steps
+
+If you have existing configuration files:
+
+1. **Remove directory configuration**: Delete or comment out the `[directories]` section
+2. **Launch from project root**: Ensure the MCP server is launched from your desired project directory
+3. **Update any scripts**: Remove directory path configuration from automation scripts
+
+## Example Usage
+
+```bash
+# In your project directory
+cd /path/to/my-project
+
+# Launch Claude with MCP server (automatically uses current directory as root)
+claude mcp add shell -- node /path/to/shemcp/dist/index.js
+
+# Now all shell commands are restricted to /path/to/my-project and subdirectories
+```
+
+The AI can now safely execute commands like:
+- `git status` (in project root)
+- `ls src/` (in subdirectory)  
+- `npm test` (in project root)
+
+But cannot execute:
+- Commands in `/etc/`
+- Commands in `/home/user/other-project/`
+- Commands outside the project tree
+
+## Backwards Compatibility
+
+This is a breaking change for configuration files, but:
+- Existing config files will still work (directory settings are ignored)
+- The security model is stricter (more secure)
+- Tool interfaces remain mostly compatible

--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ The server implements multiple layers of security:
 3. **Environment Isolation**: Sensitive environment variables are filtered out
 4. **Resource Limits**: Prevent runaway processes with timeouts and output limits
 
+## Debugging
+
+The server writes debug logs to `~/.shemcp/debug.log` which can help diagnose issues:
+
+```bash
+# View the debug log
+tail -f ~/.shemcp/debug.log
+
+# Clear the debug log
+> ~/.shemcp/debug.log
+```
+
+The log captures:
+- Server startup and configuration loading
+- All MCP requests received
+- Shutdown signals and cleanup process  
+- Any errors or exceptions
+
 ### Default Policy
 
 - **Allowed Commands**: git, gh, make, grep, sed, jq, aws, az, bash -lc

--- a/config.example.toml
+++ b/config.example.toml
@@ -2,18 +2,12 @@
 # Copy this to ~/.config/shemcp/config.toml and customize as needed
 
 [server]
-name = "mcp-shell-safe"
-version = "0.1.0"
+name = "shemcp"
+version = "0.2.0"
 
 [directories]
-# Allowed working directories (paths will be expanded, ~ becomes home directory)
-allowed = [
-    "~/projects",
-    "~/workspace", 
-    "~/dev"
-]
-# Default working directory for commands
-default = "~/projects"
+# The root directory is automatically set to the directory where the MCP server was launched
+# No configuration needed - commands can only be executed within this directory and its subdirectories
 
 [commands]
 # Regular expressions for allowed commands (case insensitive)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shemcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "bin": {
     "shemcp": "dist/index.js"

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -34,15 +34,13 @@ describe('Configuration System', () => {
 
     it('should have correct server info', () => {
       const config = ConfigLoader.loadConfig();
-      expect(config.server.name).toBe('mcp-shell-safe');
-      expect(config.server.version).toBe('0.1.0');
+      expect(config.server.name).toBe('shemcp');
     });
 
-    it('should expand tilde paths', () => {
+    it('should have root directory set to current working directory', () => {
       const config = ConfigLoader.loadConfig();
-      // Paths should be expanded from ~ to actual home directory
-      expect(config.directories.allowed.every(path => path.startsWith('/'))).toBe(true);
-      expect(config.directories.default?.startsWith('/')).toBe(true);
+      // Root directory should be set to process.cwd()
+      expect(config.directories.root).toBe(process.cwd());
     });
 
     it('should provide config file path utilities', () => {
@@ -74,8 +72,8 @@ describe('Configuration System', () => {
     it('should provide reasonable defaults', () => {
       const defaults = DEFAULT_CONFIG;
       
-      expect(defaults.server.name).toBe('mcp-shell-safe');
-      expect(defaults.directories.allowed.length).toBeGreaterThan(0);
+      expect(defaults.server.name).toBe('shemcp');
+      expect(defaults.directories.root).toBe(process.cwd());
       expect(defaults.commands.allow.length).toBeGreaterThan(0);
       expect(defaults.limits.timeout_seconds).toBeGreaterThan(0);
       expect(defaults.environment.whitelist.length).toBeGreaterThan(0);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -97,8 +97,7 @@ export class ConfigLoader {
     
     expandedConfig.directories = {
       ...config.directories,
-      allowed: config.directories.allowed.map(dir => this.expandPath(dir)),
-      default: config.directories.default ? this.expandPath(config.directories.default) : undefined,
+      root: this.expandPath(config.directories.root),
     };
 
     return expandedConfig;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2,13 +2,12 @@ import { z } from "zod";
 
 export const ConfigSchema = z.object({
   server: z.object({
-    name: z.string().default("mcp-shell-safe"),
-    version: z.string().default("0.1.0"),
+    name: z.string().default("shemcp"),
+    version: z.string().default("0.2.0"),
   }).default({}),
 
   directories: z.object({
-    allowed: z.array(z.string()).default([]),
-    default: z.string().optional(),
+    root: z.string().default(process.cwd()),
   }).default({}),
 
   commands: z.object({
@@ -35,15 +34,11 @@ export type Config = z.infer<typeof ConfigSchema>;
 
 export const DEFAULT_CONFIG: Config = {
   server: {
-    name: "mcp-shell-safe",
-    version: "0.1.0",
+    name: "shemcp",
+    version: "0.2.0",
   },
   directories: {
-    allowed: [
-      "~/projects",
-      "~/chat",
-    ],
-    default: "~/chat",
+    root: process.cwd(),
   },
   commands: {
     allow: [

--- a/test-shutdown.js
+++ b/test-shutdown.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Test script to simulate Claude Code's interaction with the MCP server
+
+import { spawn } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+console.log('[TEST] Starting MCP server...');
+const serverPath = join(__dirname, 'dist', 'index.js');
+const child = spawn('node', [serverPath], {
+  stdio: ['pipe', 'pipe', 'pipe']
+});
+
+console.log('[TEST] Server PID:', child.pid);
+
+// Set up handlers
+child.on('exit', (code, signal) => {
+  console.log('[TEST] Server exited with code:', code, 'signal:', signal);
+  if (code === 0) {
+    console.log('[TEST] ✓ Server exited cleanly');
+  } else {
+    console.log('[TEST] ✗ Server exited with error');
+  }
+});
+
+child.on('error', (err) => {
+  console.log('[TEST] Server error:', err);
+});
+
+// Wait a moment then send SIGINT like Claude Code does
+setTimeout(() => {
+  console.log('[TEST] Sending SIGINT to server...');
+  child.kill('SIGINT');
+}, 1000);
+
+// Give it time to clean up
+setTimeout(() => {
+  if (child.exitCode === null) {
+    console.log('[TEST] Server still running after 3 seconds, forcing kill');
+    child.kill('SIGKILL');
+  }
+}, 3000);


### PR DESCRIPTION
## Summary

This PR simplifies the directory configuration by automatically using the directory where the MCP server was launched as the single root directory for all operations.

## Changes

### Configuration Simplification
- Remove directories.allowed and directories.default configuration
- Root directory is now automatically set to process.cwd() (launch directory)
- All shell operations are restricted to this directory and its subdirectories

### Server Identity
- Change server name from 'mcp-shell-safe' to 'shemcp'
- Version bump to 0.2.0 for breaking configuration changes

### Implementation Changes
- Update Policy type to use rootDirectory instead of allowedCwds/defaultCwd
- Modify ensureCwd() to validate against root directory using path resolution
- Update tool schemas to remove directory-related parameters from shell_set_policy
- Simplify shell_set_cwd to work within root directory boundaries

### Documentation & Testing
- Update README with new configuration approach
- Add comprehensive migration guide (MIGRATION.md)
- Update all tests to work with new directory model
- Remove brittle version number assertions from tests

## Benefits

1. **Automatic Security**: Claude/MCP clients determine sandbox boundary by launch location
2. **Simplified Setup**: No need to configure allowed directories
3. **Project-Aware**: Each project gets its own sandbox automatically
4. **Intuitive Behavior**: Accessible directory matches where user/AI started working

## Breaking Changes

Configuration format has changed:
- Old [directories] section with allowed/default arrays is no longer needed
- Server automatically restricts operations to launch directory and subdirectories
- Existing config files will work but directory settings are ignored

See MIGRATION.md for complete migration guide.