### PR TITLE
chore: prepare first npm publish via Changesets

### DIFF
--- a/.changeset/ready-for-first-publish.md
+++ b/.changeset/ready-for-first-publish.md
@@ -1,0 +1,5 @@
+---
+"shemcp": minor
+---
+
+Set up npm publishing: add Changesets, CI, release workflow, README badges and installation docs prioritizing npm, and MIT license.


### PR DESCRIPTION
This PR sets up automated releases with Changesets and prepares the first publish.\n\nHighlights:\n- Add Changesets config and initial changeset (minor) to trigger first release.\n- Add CI for build/test and release workflow with provenance.\n- Enforce changesets on PRs touching src/** or package.json.\n- README prioritized npm install and added badges.\n- MIT license and package metadata finalized.\n\nAfter merge:\n- The Release workflow will open a Release PR ("Version Packages").\n- Merge that PR to publish to npm (requires NPM_TOKEN secret, already set).\n\n