### PR TITLE
chore(release): fix changesets action by adding changelog plugin

### DIFF
--- a/.changeset/ready-for-first-publish.md
+++ b/.changeset/ready-for-first-publish.md
@@ -1,0 +1,5 @@
+---
+"shemcp": minor
+---
+
+Set up npm publishing: add Changesets, CI, release workflow, README badges and installation docs prioritizing npm, and MIT license.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "shemcp": "dist/index.js"
       },
       "devDependencies": {
+        "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.27.9",
         "@types/node": "^22.18.1",
         "@vitest/ui": "^3.2.4",
@@ -83,6 +84,18 @@
       "license": "MIT",
       "dependencies": {
         "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/changelog-github": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.1.tgz",
+      "integrity": "sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-github-info": "^0.6.0",
+        "@changesets/types": "^6.1.0",
+        "dotenv": "^8.1.0"
       }
     },
     "node_modules/@changesets/cli": {
@@ -162,6 +175,17 @@
         "@manypkg/get-packages": "^1.1.3",
         "picocolors": "^1.1.0",
         "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-github-info": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
+      "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "^1.4.0",
+        "node-fetch": "^2.5.0"
       }
     },
     "node_modules/@changesets/get-release-plan": {
@@ -1765,6 +1789,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1832,6 +1863,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dunder-proto": {
@@ -2737,6 +2778,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -3661,6 +3723,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -3953,6 +4022,24 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.1",
+    "@changesets/cli": "^2.27.9",
     "@types/node": "^22.18.1",
     "@vitest/ui": "^3.2.4",
-    "@changesets/cli": "^2.27.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"


### PR DESCRIPTION
The Release workflow failed due to missing devDependency @changesets/changelog-github (used by .changeset/config.json for GitHub changelog). This PR adds it and should let the Release job open the Version PR.\n\nDetails:\n- Install @changesets/changelog-github@^0.5.1 as a devDependency.\n- Update lockfile.\n\nAfter merge:\n- The Release workflow should succeed and open the "Version Packages" PR.\n