### PR TITLE
chore: add changeset for git-root sandbox + relative cwd + shell_info

### DIFF
--- a/.changeset/easy-laws-shake.md
+++ b/.changeset/easy-laws-shake.md
@@ -1,0 +1,9 @@
+---
+"shemcp": minor
+---
+
+- Sandbox root now resolves to the Git repository root by default (fallback to the current working directory), with optional overrides via SHEMCP_ROOT or MCP_SANDBOX_ROOT.
+- Removed the shell_set_cwd tool; shell_exec cwd must be RELATIVE to the sandbox root. Absolute paths are rejected with clear error messages that include the received path and the sandbox root.
+- Added shell_info tool for introspection (reports sandbox_root and resolves relative cwd inputs, including within_sandbox checks).
+- Hardened ensureCwd with realpath and boundary checks to prevent symlink escapes and ensure directory accessibility.
+- Updated docs and tests to reflect the new behavior.


### PR DESCRIPTION
Adds a Changeset (minor) documenting: git-root sandbox default with env overrides, removal of shell_set_cwd, relative-only cwd enforcement with clear errors, new shell_info tool, and ensureCwd hardening. This enables the release workflow to generate a release PR.