### PR TITLE
docs: README Quick reference + CHANGELOG Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # shemcp
 
+## Unreleased
+
+### Minor Changes
+
+- Sandbox root now resolves to the Git repository root by default (fallback to the current working directory), with optional overrides via `SHEMCP_ROOT` or `MCP_SANDBOX_ROOT`.
+- Removed the `shell_set_cwd` tool; `shell_exec` cwd must be RELATIVE to the sandbox root. Absolute paths are rejected with clear error messages that include the received path and the sandbox root.
+- Added `shell_info` tool for introspection (reports `sandbox_root` and resolves relative `cwd` inputs, including `within_sandbox` checks).
+- Hardened `ensureCwd` with `realpath` and boundary checks to prevent symlink escapes and ensure directory accessibility.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ Update the security policy at runtime.
   - `max_bytes`: Maximum output size per stream
   - `env_whitelist`: Array of environment variables to pass through
 
+## Quick reference
+
+Ask your MCP client to call these tools with the following inputs:
+
+- `shell_info` examples:
+  - `{ "cwd": "." }` → returns `sandbox_root`, resolves to the root, and confirms within sandbox
+  - `{ "cwd": "src" }` → returns resolved `src` path and `within_sandbox: true` if it exists/inside
+
+- `shell_exec` examples:
+  - `{ "cmd": "git", "args": ["status"], "cwd": "." }`
+  - `{ "cmd": "npm", "args": ["test"], "cwd": "." }`
+  - `{ "cmd": "ls", "args": ["-la"], "cwd": "src" }`
+
 ## Quick Start
 
 ### 1) Install (npm)


### PR DESCRIPTION
Adds Quick reference with shell_info/shell_exec examples. Updates CHANGELOG with Unreleased section summarizing Git-root sandbox, cwd rules, shell_info addition, and hardened ensureCwd.