### PR TITLE
fix: resolve merge conflicts in src/index.ts (CI fix)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,17 +264,10 @@ export const tools: Tool[] = [
         args: { type: "array", items: { type: "string" }, default: [], description: "Command arguments as an array of strings (e.g., ['status', '--short'])" },
         cwd: { type: "string", description: "Relative path from sandbox root (no absolute paths)" },
         // Deprecated: prefer timeout_seconds; kept for backward-compat
-<<<<<<< HEAD
         timeout_ms: { type: "number", minimum: 1, maximum: 300000, description: "Command timeout in milliseconds (deprecated, use timeout_seconds instead)" },
         // New optional per-request overrides
         timeout_seconds: { type: "number", minimum: 1, maximum: 300, description: "Command timeout in seconds (1-300, will be clamped to policy limits)" },
         max_output_bytes: { type: "number", minimum: 1000, maximum: 10000000, description: "Maximum output size in bytes (1000-10M, will be clamped to policy limits)" }
-=======
-        timeout_ms: { type: "number", minimum: 1, maximum: 300000 },
-        // New optional per-request overrides
-        timeout_seconds: { type: "number", minimum: 1, maximum: 300 },
-        max_output_bytes: { type: "number", minimum: 1000, maximum: 10000000 }
->>>>>>> 9567ffa (Add per-request limit overrides and expand command list)
       },
       required: ["cmd"]
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Resolves merge conflict markers in `src/index.ts` that are causing CI failures on main branch
- Fixes build failures that were merged with PR #19

## Problem
The main branch currently has failing CI due to unresolved merge conflict markers at lines 267, 272, and 277 in src/index.ts.

## Solution
- Removed merge conflict markers
- Kept the version with full property descriptions for better API documentation

## Test Plan
- [x] Build passes locally (`npm run build`)
- [x] Tests pass locally (`npm test`)
- [ ] CI/CD pipeline passes

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)