### PR TITLE
fix: add --repo flag to gh pr merge command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,9 @@ jobs:
             echo "Waiting for CI checks to begin..."
             sleep 30
             
-            # Auto-merge the PR
+            # Auto-merge the PR (use --repo flag since we're not in a git directory)
             echo "Auto-merging release PR #$RELEASE_PR_NUMBER..."
-            gh pr merge $RELEASE_PR_NUMBER --squash --auto --delete-branch
+            gh pr merge $RELEASE_PR_NUMBER --repo ${{ github.repository }} --squash --auto --delete-branch
             
             echo "✅ Release PR #$RELEASE_PR_NUMBER auto-merged successfully!"
           else

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,17 +264,10 @@ export const tools: Tool[] = [
         args: { type: "array", items: { type: "string" }, default: [], description: "Command arguments as an array of strings (e.g., ['status', '--short'])" },
         cwd: { type: "string", description: "Relative path from sandbox root (no absolute paths)" },
         // Deprecated: prefer timeout_seconds; kept for backward-compat
-<<<<<<< HEAD
         timeout_ms: { type: "number", minimum: 1, maximum: 300000, description: "Command timeout in milliseconds (deprecated, use timeout_seconds instead)" },
         // New optional per-request overrides
         timeout_seconds: { type: "number", minimum: 1, maximum: 300, description: "Command timeout in seconds (1-300, will be clamped to policy limits)" },
         max_output_bytes: { type: "number", minimum: 1000, maximum: 10000000, description: "Maximum output size in bytes (1000-10M, will be clamped to policy limits)" }
-=======
-        timeout_ms: { type: "number", minimum: 1, maximum: 300000 },
-        // New optional per-request overrides
-        timeout_seconds: { type: "number", minimum: 1, maximum: 300 },
-        max_output_bytes: { type: "number", minimum: 1000, maximum: 10000000 }
->>>>>>> 9567ffa (Add per-request limit overrides and expand command list)
       },
       required: ["cmd"]
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fixes the Release workflow failure that occurs when trying to auto-merge release PRs
- Resolves the "fatal: not a git repository" error in the auto-merge step

## Problem
The Release workflow's auto-merge-release-pr job was failing with:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This happened because the workflow doesn't checkout the repository (which is correct for this use case), but the `gh pr merge` command was expecting to be run from within a git repository.

## Solution
Added the `--repo ${{ github.repository }}` flag to the `gh pr merge` command, which allows it to work without being in a git directory.

## Test Plan
- [x] Verified the same pattern is used in other parts of the workflow
- [ ] CI/CD pipeline passes
- [ ] Next release PR will auto-merge successfully

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)