### PR TITLE
fix: add workflow_dispatch to enable manual release triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:  # Allows manual triggering of releases
 
 jobs:
   release:
@@ -134,6 +135,9 @@ jobs:
           
       - name: Find and auto-merge release PR
         env:
+          # Note: Using GITHUB_TOKEN here means the merge won't trigger workflows.
+          # To have the merge trigger the release workflow again, you'd need to use
+          # a Personal Access Token (PAT) stored as a secret instead.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Searching for release PR..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,9 @@ jobs:
             echo "Waiting for CI checks to begin..."
             sleep 30
             
-            # Auto-merge the PR
+            # Auto-merge the PR (use --repo flag since we're not in a git directory)
             echo "Auto-merging release PR #$RELEASE_PR_NUMBER..."
-            gh pr merge $RELEASE_PR_NUMBER --squash --auto --delete-branch
+            gh pr merge $RELEASE_PR_NUMBER --repo ${{ github.repository }} --squash --auto --delete-branch
             
             echo "✅ Release PR #$RELEASE_PR_NUMBER auto-merged successfully!"
           else

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,17 +264,10 @@ export const tools: Tool[] = [
         args: { type: "array", items: { type: "string" }, default: [], description: "Command arguments as an array of strings (e.g., ['status', '--short'])" },
         cwd: { type: "string", description: "Relative path from sandbox root (no absolute paths)" },
         // Deprecated: prefer timeout_seconds; kept for backward-compat
-<<<<<<< HEAD
         timeout_ms: { type: "number", minimum: 1, maximum: 300000, description: "Command timeout in milliseconds (deprecated, use timeout_seconds instead)" },
         // New optional per-request overrides
         timeout_seconds: { type: "number", minimum: 1, maximum: 300, description: "Command timeout in seconds (1-300, will be clamped to policy limits)" },
         max_output_bytes: { type: "number", minimum: 1000, maximum: 10000000, description: "Maximum output size in bytes (1000-10M, will be clamped to policy limits)" }
-=======
-        timeout_ms: { type: "number", minimum: 1, maximum: 300000 },
-        // New optional per-request overrides
-        timeout_seconds: { type: "number", minimum: 1, maximum: 300 },
-        max_output_bytes: { type: "number", minimum: 1000, maximum: 10000000 }
->>>>>>> 9567ffa (Add per-request limit overrides and expand command list)
       },
       required: ["cmd"]
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Adds `workflow_dispatch` trigger to the Release workflow
- Enables manual triggering of releases when automatic triggers fail
- Documents the GITHUB_TOKEN limitation that prevents workflow chaining

## Problem
The release automation is incomplete because:
1. When the Release PR (#21) was auto-merged using GITHUB_TOKEN, it didn't trigger the Release workflow again
2. This is a GitHub security feature - workflows triggered by GITHUB_TOKEN don't trigger other workflows to prevent infinite loops
3. As a result, the npm package wasn't published and no GitHub release was created
4. The workflow couldn't be manually triggered to fix this because it lacked `workflow_dispatch`

## Solution
1. **Immediate fix**: Add `workflow_dispatch` trigger so releases can be manually triggered
2. **Documentation**: Added comments explaining why auto-merged PRs don't trigger workflows
3. **Future improvement**: To fully automate, would need to use a Personal Access Token (PAT) instead of GITHUB_TOKEN for auto-merge

## Current State
- Version 0.6.0 is ready to release (version bumped, changelog updated)
- The changeset file is still present (wasn't consumed by publish)
- Once this PR is merged, we can manually trigger the Release workflow to publish

## Next Steps
After merging this PR:
1. Go to Actions → Release workflow
2. Click "Run workflow" → Run on main branch
3. This will publish to npm and create the GitHub release

## Long-term Solution
For full automation, consider:
- Creating a GitHub PAT and storing it as a secret (e.g., `RELEASE_TOKEN`)
- Using that token in the auto-merge step instead of GITHUB_TOKEN
- This would allow the merge to trigger subsequent workflows

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)