### PR TITLE
fix: GitHub Release and Packages publishing

### DIFF
--- a/.changeset/fix-github-release-packages.md
+++ b/.changeset/fix-github-release-packages.md
@@ -1,0 +1,18 @@
+---
+"shemcp": patch
+---
+
+Fix GitHub Release and GitHub Packages publishing
+
+Fixed the Release workflow to properly detect when npm publish succeeds and trigger GitHub Release creation and GitHub Packages publishing accordingly.
+
+Previously, these steps were only triggered when changesets reported publishing in the current run, but when the Release PR is merged, the actual publish happens without changesets reporting it as "published".
+
+Now the workflow:
+- Checks if the current package version matches what's on npm
+- If it does, it means a publish happened (either just now or in the PR merge)
+- Uses this detection to trigger GitHub Release and GitHub Packages steps
+
+This ensures that every npm release gets:
+- A corresponding GitHub Release with changelog
+- A GitHub Packages publication for alternative installation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,29 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Check if package was published
+        id: publish_check
+        run: |
+          # Get the current version from package.json
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Current version: $CURRENT_VERSION"
+
+          # Check if this version exists on npm
+          NPM_VERSION=$(npm view shemcp version 2>/dev/null || echo "")
+          echo "Latest npm version: $NPM_VERSION"
+
+          # If versions match, a publish happened (either just now or very recently)
+          if [ "$CURRENT_VERSION" = "$NPM_VERSION" ]; then
+            echo "Package version $CURRENT_VERSION was published!"
+            echo "published=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "No publish detected"
+            echo "published=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to GitHub Packages
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.publish_check.outputs.published == 'true'
         run: |
           # Configure npm for GitHub Packages
           echo "@acartine:registry=https://npm.pkg.github.com" >> ~/.npmrc
@@ -69,11 +90,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Extract changelog for release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.publish_check.outputs.published == 'true'
         id: changelog
         run: |
           # Extract the latest version section from CHANGELOG.md
-          VERSION="${{ steps.changesets.outputs.publishedPackages[0].version }}"
+          VERSION="${{ steps.publish_check.outputs.version }}"
           echo "Extracting changelog for version $VERSION"
           
           # Find the section for this version and extract until the next version
@@ -90,15 +111,15 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
           
       - name: Create GitHub Release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.publish_check.outputs.published == 'true'
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.changesets.outputs.publishedPackages[0].version }}
-          name: 🚀 Release v${{ steps.changesets.outputs.publishedPackages[0].version }}
+          tag_name: v${{ steps.publish_check.outputs.version }}
+          name: 🚀 Release v${{ steps.publish_check.outputs.version }}
           body: |
-            ## 📦 What's New in v${{ steps.changesets.outputs.publishedPackages[0].version }}
+            ## 📦 What's New in v${{ steps.publish_check.outputs.version }}
             
             ${{ env.RELEASE_NOTES }}
             
@@ -106,7 +127,7 @@ jobs:
             
             - **npm Package**: [shemcp](https://www.npmjs.com/package/shemcp)
             - **Repository**: [acartine/shemcp](https://github.com/acartine/shemcp)
-            - **Version**: v${{ steps.changesets.outputs.publishedPackages[0].version }}
+            - **Version**: v${{ steps.publish_check.outputs.version }}
             - **License**: MIT
             
             ## 🚀 Installation


### PR DESCRIPTION
$(cat <<'EOF'
## 🐛 The Bug
When version 0.7.1 was released:
- ✅ npm package was published successfully
- ❌ GitHub Release was NOT created
- ❌ GitHub Packages was NOT published

## 🔍 Root Cause
The Release workflow had a logic flaw:
1. When the Release PR is merged, it triggers the Release workflow again
2. But changesets have already been consumed (in the PR)
3. So `steps.changesets.outputs.published` is `false`
4. GitHub Release and Packages steps check for `published == 'true'` and skip
5. Result: npm publishes but GitHub features don't work

## 🛠️ The Fix
Added a new "Check if package was published" step that:
- Gets the current version from package.json
- Checks if this version exists on npm
- If versions match, sets `published=true`
- All downstream steps now use this detection instead of changesets output

## 🧪 Testing
This PR includes a changeset that will:
1. Bump version to 0.7.2
2. Trigger the full release flow
3. **This time it should create:**
   - ✅ npm package (v0.7.2)
   - ✅ GitHub Release (v0.7.2)
   - ✅ GitHub Packages (@acartine/shemcp@0.7.2)

## 📋 Verification Steps
After this PR is merged and the release completes:
1. Check npm: `npm view shemcp version` (should show 0.7.2)
2. Check GitHub Releases tab (should show v0.7.2)
3. Check GitHub Packages tab (should show @acartine/shemcp)

## 🎯 Why This Matters
- Users expect GitHub Releases for version tracking
- GitHub Packages provides an alternative registry
- Automated release notes save maintainer time
- Complete automation = happy developers

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)