### PR TITLE
fix: GitHub Packages auth and release v0.7.3

### DIFF
--- a/.changeset/fix-github-packages-auth.md
+++ b/.changeset/fix-github-packages-auth.md
@@ -1,0 +1,16 @@
+---
+"shemcp": patch
+---
+
+Fix GitHub Packages authentication in Release workflow
+
+Corrects the npm authentication method for GitHub Packages publishing. The previous approach of appending to ~/.npmrc conflicted with the setup-node action's configuration, causing authentication failures.
+
+This fix:
+- Uses `npm config set` instead of direct file manipulation
+- Ensures proper authentication token configuration
+- Will enable GitHub Packages publication for all future releases
+
+Testing with v0.7.3 release to verify:
+- GitHub Release creation works
+- GitHub Packages publication succeeds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,11 @@ jobs:
       - name: Publish to GitHub Packages
         if: steps.publish_check.outputs.published == 'true'
         run: |
-          # Configure npm for GitHub Packages
-          echo "@acartine:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-
           # Update package name for GitHub Packages (scoped to owner)
           npm pkg set name='@acartine/shemcp'
+
+          # Configure authentication for GitHub Packages
+          npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
 
           # Publish to GitHub Packages
           npm publish --registry=https://npm.pkg.github.com --access public


### PR DESCRIPTION
$(cat <<'EOF'
## 🎯 The Goal
Fix GitHub Packages authentication and test the complete release automation with v0.7.3.

## 🔍 What Happened
- v0.7.2 published to npm ✅
- GitHub Release creation failed ❌ (workflow stopped due to Packages auth error)
- GitHub Packages publication failed ❌ (authentication error)

## 🔧 The Fix
Changed the GitHub Packages authentication from:
```bash
echo "//npm.pkg.github.com/:_authToken=TOKEN" >> ~/.npmrc  # Conflicts with setup-node
```
To:
```bash
npm config set //npm.pkg.github.com/:_authToken=TOKEN  # Works with setup-node
```

## 🧪 Testing with v0.7.3
This PR includes a changeset that will trigger v0.7.3 release to test:
1. 📦 npm package publication
2. 🎉 GitHub Release creation  
3. 📦 GitHub Packages publication

## 📊 Expected Results
When this PR is merged:
1. Release PR for v0.7.3 will be created
2. Auto-merge with RELEASE_TOKEN
3. Publish to npm as `shemcp@0.7.3`
4. Create GitHub Release `v0.7.3` 
5. Publish to GitHub Packages as `@acartine/shemcp@0.7.3`

All three outputs should finally work! 🎆

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)