### PR TITLE
fix: make GitHub Packages publish non-blocking

### DIFF
--- a/.changeset/non-blocking-github-packages.md
+++ b/.changeset/non-blocking-github-packages.md
@@ -1,0 +1,7 @@
+---
+"shemcp": patch
+---
+
+Make GitHub Packages publish non-blocking
+
+The GitHub Packages publish step now continues on error to ensure GitHub Release creation happens even if GitHub Packages fails. This is important because GitHub Packages can fail for permission reasons (e.g., trying to create an org package for a user account) but we still want the GitHub Release to be created.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Publish to GitHub Packages
         if: steps.detect_publish.outputs.published == 'true'
+        continue-on-error: true
         run: |
           # Update package name for GitHub Packages (scoped to owner)
           npm pkg set name='@acartine/shemcp'
@@ -94,7 +95,7 @@ jobs:
           npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
 
           # Publish to GitHub Packages
-          npm publish --registry=https://npm.pkg.github.com --access public
+          npm publish --registry=https://npm.pkg.github.com --access public || echo "GitHub Packages publish failed (non-blocking)"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           


### PR DESCRIPTION
## Summary

Makes the GitHub Packages publish step non-blocking so that GitHub Release creation can proceed even if GitHub Packages fails.

## Problem

In v0.7.5 release:
- ✅ npm package published successfully
- ✅ Our detection logic worked correctly
- ❌ GitHub Packages failed with 403 Forbidden (can't create org package for user account)
- ❌ GitHub Release was NOT created because workflow stopped on GitHub Packages failure

## Solution

Add `continue-on-error: true` to the GitHub Packages step so failures don't block the rest of the workflow.

## Testing

This PR includes a changeset for v0.7.6 to verify:
1. ✅ npm package publishes
2. ✅ GitHub Release IS created even though GitHub Packages fails
3. ⚠️ GitHub Packages fails gracefully (expected for user accounts)