### PR TITLE
fix: remove GitHub Packages publishing

### DIFF
--- a/.changeset/remove-github-packages.md
+++ b/.changeset/remove-github-packages.md
@@ -1,0 +1,7 @@
+---
+"shemcp": patch
+---
+
+Remove GitHub Packages publishing from release workflow
+
+GitHub Packages doesn't support publishing for user accounts (only organizations), so removing this step to keep the workflow clean and avoid unnecessary error messages.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,21 +84,6 @@ jobs:
           fi
 
 
-      - name: Publish to GitHub Packages
-        if: steps.detect_publish.outputs.published == 'true'
-        continue-on-error: true
-        run: |
-          # Update package name for GitHub Packages (scoped to owner)
-          npm pkg set name='@acartine/shemcp'
-
-          # Configure authentication for GitHub Packages
-          npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
-
-          # Publish to GitHub Packages
-          npm publish --registry=https://npm.pkg.github.com --access public || echo "GitHub Packages publish failed (non-blocking)"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
       - name: Extract changelog for release
         if: steps.detect_publish.outputs.published == 'true'
         id: changelog


### PR DESCRIPTION
## Summary

Removes the GitHub Packages publishing step since it's not supported for user accounts.

## Context

GitHub Packages only supports scoped packages for organizations, not user accounts. The step was failing with:
```
403 Forbidden - Permission installation not allowed to Create organization package
```

## Solution

Completely remove the GitHub Packages publishing step. The release workflow now:
1. ✅ Publishes to npm
2. ✅ Creates GitHub Release
3. ❌ ~~Publishes to GitHub Packages~~ (removed)

This keeps the workflow clean and focused on what actually works.