### PR TITLE
fix: add shebang to enable npx execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {


### PR DESCRIPTION
## Summary
- Added `#!/usr/bin/env node` shebang to `src/index.ts` to fix npx execution
- Without the shebang, npx treats `dist/index.js` as a shell script, causing "import: command not found" errors
- The shebang tells the OS to use node to execute the JavaScript file

## Root Cause
When `package.json` defines a bin entry pointing to `dist/index.js`, npx makes the file executable and runs it. Without a shebang line, the OS defaults to using `/bin/sh` to execute the file, which tries to interpret JavaScript as shell commands.

## Test Plan
- [x] Local build passes
- [x] Shebang verified in `dist/index.js` after build
- [x] Local execution successful: `./dist/index.js` runs without shell errors
- [x] Manually tested: edited npx cached file with shebang, confirmed fix works
- [ ] CI tests pass
- [ ] After publish: `npx -y shemcp` works without errors

## Notes
- The TypeScript compiler preserves the shebang during compilation
- `dist/` is gitignored, so only source file changes are committed
- Fix will take effect once a new version is published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)