### PR TITLE
chore: add changeset for shebang fix

### DIFF
--- a/.changeset/happy-nodes-fix.md
+++ b/.changeset/happy-nodes-fix.md
@@ -1,0 +1,5 @@
+---
+"shemcp": patch
+---
+
+Fix npx execution by adding shebang line to dist/index.js. Without the shebang, npx attempts to execute the file as a shell script, causing "import: command not found" errors.


### PR DESCRIPTION
## Summary
- Add patch changeset for the shebang fix (PR #63)
- This will trigger a 0.14.0 → 0.14.1 patch release
- Enables `npx -y shemcp` to work without "import: command not found" errors

## Context
The shebang fix was merged in PR #63, but a changeset is required to publish a new npm version. This changeset will trigger the automated release workflow.

## Test Plan
- [x] Build passes
- [x] Tests pass
- [ ] CI checks pass
- [ ] After merge: Version bump and release workflow triggers

## Notes
- Changeset type: `patch` (bug fix)
- Expected version: 0.14.1
- The changeset bot will create a "Version Packages" PR after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)