### PR TITLE
fix: build TypeScript before npm publish

### DIFF
--- a/.changeset/brave-plants-build.md
+++ b/.changeset/brave-plants-build.md
@@ -1,0 +1,5 @@
+---
+"shemcp": patch
+---
+
+Fix npm publish workflow to build TypeScript before publishing. The publish step now runs npm ci and npm run build to ensure dist/index.js includes the shebang and all latest changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,10 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: npm publish --provenance --access public
+          publish: |
+            npm ci
+            npm run build
+            npm publish --provenance --access public
           title: "Release: Update versions and publish to npm"
           commit: "chore: release packages"
         env:


### PR DESCRIPTION
## Summary
- Update release workflow to build TypeScript before publishing to npm
- Add changeset for patch release (0.14.1 → 0.14.2)
- Fixes issue where published package had stale dist/ files without shebang

## Root Cause
The changeset action's publish step was running `npm publish` directly without building first. This meant the published package contained old dist/ files that didn't include the shebang fix from PR #63, causing npx execution to fail.

## Solution
Modified the publish command to be a multi-line script that:
1. Runs `npm ci` to ensure clean dependencies
2. Runs `npm run build` to compile TypeScript with latest source
3. Runs `npm publish --provenance --access public`

## Test Plan
- [x] Workflow file updated with multi-line publish command
- [x] Changeset created for patch release
- [ ] CI checks pass
- [ ] After merge: Version bump to 0.14.2
- [ ] After release: `npx -y shemcp` works correctly with MCP server staying open

## Notes
- This is a critical fix for the npm package functionality
- The shebang was in source code but not making it to npm package
- Related to PR #63 (shebang fix) and PR #64 (changeset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)