### PR TITLE
chore: add changeset for prepack script fix

### DIFF
--- a/.changeset/fresh-sheep-build.md
+++ b/.changeset/fresh-sheep-build.md
@@ -1,0 +1,5 @@
+---
+"shemcp": patch
+---
+
+Fix npm publish to include built files with shebang. Added prepack script that automatically builds TypeScript and runs tests before packaging, ensuring dist/index.js always has the shebang line needed for npx execution.


### PR DESCRIPTION
## Summary
- Add patch changeset for the prepack script fix (PR #68)
- This will trigger a 0.14.2 → 0.14.3 patch release
- Fixes npm publish to include built dist/ files with shebang

## Context
PR #68 added a `prepack` script that automatically builds TypeScript before packaging. This changeset will trigger the release workflow to publish the fixed version to npm.

## Expected Outcome
- Version bump to 0.14.3
- Published package will have fresh dist/ files built by prepack hook
- `npx -y shemcp` will work correctly with the shebang

🤖 Generated with [Claude Code](https://claude.com/claude-code)