### PR TITLE
fix: use fileURLToPath for main module check with symlinks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   CallToolRequestSchema
 } from "@modelcontextprotocol/sdk/types.js";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 // Load package.json without using JSON import attributes (Node 18 compatible)
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -119,7 +120,7 @@ export async function startServer() {
 }
 
 // Only start if this is the main module
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   let serverInstance: { server: typeof server; transport: StdioServerTransport } | null = null;
 
   // Track if we're already shutting down


### PR DESCRIPTION
## Summary
- Fix main module detection to work correctly with symlinked binaries
- Use `fileURLToPath` to properly compare paths with symlinks
- This fixes the server never starting when run via `npx -y shemcp`

## Root Cause
The previous check compared `import.meta.url` (a file:// URL) with `process.argv[1]` (a file path), which fails when npm creates a symlink in the bin directory.

```typescript
// Before (broken with symlinks)
if (import.meta.url === `file://${process.argv[1]}`) {
  startServer();
}

// After (works with symlinks)
if (process.argv[1] === fileURLToPath(import.meta.url)) {
  startServer();
}
```

## Testing
```bash
npm run build
./dist/index.js  # Should start server
```

## Impact
This is the actual fix for `npx -y shemcp` not working. The shebang and prepack fixes were necessary but not sufficient - the server was starting but immediately exiting because this check failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)