### PR TITLE
chore: add changeset for symlink main module fix

### DIFF
--- a/.changeset/brave-bears-run.md
+++ b/.changeset/brave-bears-run.md
@@ -1,0 +1,5 @@
+---
+"shemcp": patch
+---
+
+Fix server startup when executed via npx with symlinked binaries. Changed main module check from comparing file:// URLs to using fileURLToPath for proper path resolution, allowing the server to start correctly when run through npm bin symlinks.


### PR DESCRIPTION
## Summary
- Add patch changeset for the symlink fix (PR #71)
- This will trigger a 0.14.3 → 0.14.4 patch release
- Fixes server not starting when run via npx with symlinked binaries

## Context
PR #71 fixed the main module check to properly handle symlinks by using `fileURLToPath`. This changeset will trigger the release workflow to publish the working version to npm.

## Expected Outcome
- Version bump to 0.14.4
- `npx -y shemcp` will actually start the MCP server and stay running
- The server will properly wait for stdin input instead of exiting immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)