### PR TITLE
fix: resolve symlink paths in main module check for npx execution

### DIFF
--- a/.changeset/purple-falcons-watch.md
+++ b/.changeset/purple-falcons-watch.md
@@ -1,0 +1,5 @@
+---
+"shemcp": patch
+---
+
+Fix npx execution failing silently due to symlink path resolution in main module check. The main module check was comparing process.argv[1] directly with fileURLToPath(import.meta.url), but when run via npx, argv[1] contains a symlink path while the URL path is resolved. Added null check and realpathSync() to properly resolve and compare paths, allowing the server to start correctly when executed via npx -y shemcp.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 const require = createRequire(import.meta.url);
 // Load package.json without using JSON import attributes (Node 18 compatible)
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -120,7 +121,8 @@ export async function startServer() {
 }
 
 // Only start if this is the main module
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+// Resolve symlinks in argv[1] to handle npx bin symlinks
+if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   let serverInstance: { server: typeof server; transport: StdioServerTransport } | null = null;
 
   // Track if we're already shutting down


### PR DESCRIPTION
## Summary
- Fixes npx execution failing silently due to symlink path resolution mismatch
- Added null check for process.argv[1]
- Use realpathSync() to resolve symlink paths before comparing with main module path

## Problem
When running the server via `npx -y shemcp`, the main module check was failing because:
- `process.argv[1]` contains a symlink path (from npx's bin directory)
- `fileURLToPath(import.meta.url)` returns the resolved real path
- Direct string comparison failed, causing the server to exit silently without starting

## Solution
- Import `realpathSync` from `node:fs`
- Add null check for `process.argv[1]` before comparison
- Resolve symlinks using `realpathSync()` before comparing paths
- This ensures the comparison works correctly regardless of how the script is invoked

## Changes
- `/Users/cartine/shemcp/src/index.ts`: Added import and updated main module check
- `/Users/cartine/shemcp/.changeset/purple-falcons-watch.md`: Added patch changeset

## Test Plan
- [ ] Verify `npx -y shemcp` starts the server successfully
- [ ] Verify direct execution still works
- [ ] Verify CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)